### PR TITLE
adjusted docs, improve browsing of impls outside of prelude

### DIFF
--- a/benches/id.rs
+++ b/benches/id.rs
@@ -1,31 +1,31 @@
-use can_types::prelude::*;
+use can_types::{conversion::Conversion, protocol::j1939::identifier::IdJ1939};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-fn id_to_bits(id: &Id<J1939>) {
+fn id_to_bits(id: &IdJ1939) {
     let id_bits = id.into_bits();
     assert_eq!(0b000_011_0_0_11110000_00000100_00000000, id_bits);
 }
 
 #[cfg(feature = "alloc")]
-fn id_to_hex(id: &Id<J1939>) {
+fn id_to_hex(id: &IdJ1939) {
     let id_hex = id.into_hex();
     assert_eq!("0CF00400", id_hex)
 }
 
 fn id_from_bits(bits: u32) {
-    let id = Id::<J1939>::from_bits(bits);
+    let id = IdJ1939::from_bits(bits);
     assert_eq!(0b000_011_0_0_11110000_00000100_00000000, id.into_bits());
 }
 
 fn id_from_hex(hex_str: &str) {
-    let id = Id::<J1939>::from_hex(hex_str);
+    let id = IdJ1939::from_hex(hex_str);
     assert_eq!(0b000_011_0_0_11110000_00000100_00000000, id.into_bits());
 }
 
 pub fn id_bench(c: &mut Criterion) {
     let id_bits: u32 = 217056256;
     let id_hex = "0CF00400";
-    let id = Id::<J1939>::from_bits(id_bits);
+    let id = IdJ1939::from_bits(id_bits);
 
     let mut group = c.benchmark_group("id");
     group.throughput(criterion::Throughput::Elements(1));

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -13,13 +13,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use crate::{
+    payload::{Data, Name, Pdu},
+    protocol::{can2_a::identifier::IdCan2A, can2_b::identifier::IdCan2B},
+};
+
 if_alloc! {
     use crate::alloc::string::String;
 }
-
-use crate::identifier::Id;
-use crate::prelude::{Data, Name, Pdu};
-use crate::protocol::{Can2A, Can2B};
 
 /// A trait for types that can be converted to and from bitfield representations (`bits`)
 /// of integers and hexadecimal string slices (hex).
@@ -70,16 +71,14 @@ impl From<Pdu<Name>> for Pdu<Data> {
     }
 }
 
-impl From<Id<Can2A>> for Id<Can2B> {
-    fn from(value: Id<Can2A>) -> Self {
+impl From<IdCan2A> for IdCan2B {
+    fn from(value: IdCan2A) -> Self {
         Self::from_bits(value.into_bits().into())
     }
 }
 
 #[cfg(test)]
 mod impl_tests {
-    use crate::prelude::{Data, Name, Pdu};
-
     use super::*;
 
     #[test]
@@ -100,9 +99,9 @@ mod impl_tests {
 
     #[test]
     fn test_extended_from() {
-        let id_std_a = Id::<Can2A>::from_hex("00F");
-        let id_ext_a = Id::<Can2B>::from(id_std_a);
+        let id_std_a = IdCan2A::from_hex("00F");
+        let id_ext_a = IdCan2B::from(id_std_a);
 
-        assert_eq!(Id::<Can2B>::from_hex("0000000F"), id_ext_a);
+        assert_eq!(IdCan2B::from_hex("0000000F"), id_ext_a);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! ```rust
 //! # use can_types::prelude::*;
 //! # fn main() -> Result<(), anyhow::Error> {
-//! let id_a = Id::<J1939>::try_from_hex("0CF00400")?;
+//! let id_a = IdJ1939::try_from_hex("0CF00400")?;
 //!
 //! assert_eq!(3, id_a.priority());
 //! assert_eq!(SourceAddr::Some(0), id_a.source_address());
@@ -36,12 +36,12 @@
 //! ```rust
 //! # use can_types::prelude::*;
 //! # fn main() -> Result<(), anyhow::Error> {
-//! let id_a = Id::<J1939>::try_from_hex("18FEF200")?;
+//! let id_a = IdJ1939::try_from_hex("18FEF200")?;
 //!
 //! assert_eq!(CommunicationMode::Broadcast, id_a.pgn().communication_mode());
 //! assert_eq!(GroupExtension::Some(242), id_a.pgn().group_extension());
 //!  
-//! let id_b = Id::<J1939>::try_from_hex("0C00290B")?;
+//! let id_b = IdJ1939::try_from_hex("0C00290B")?;
 //!         
 //! // SA 11 = Brakes
 //! assert_eq!(SourceAddr::Some(11), id_b.source_address());
@@ -76,10 +76,21 @@ pub mod message;
 pub mod payload;
 pub mod protocol;
 
+#[doc(hidden)]
 pub mod prelude {
-    pub use crate::conversion::*;
-    pub use crate::identifier::*;
-    pub use crate::message::*;
-    pub use crate::payload::*;
-    pub use crate::protocol::*;
+    use super::{conversion, identifier, message, payload, protocol};
+
+    pub use conversion::Conversion;
+    pub use identifier::{Id, IsProtocol};
+    pub use message::Message;
+    pub use payload::{Data, IsDataUnit, Name, Pdu};
+    pub use protocol::{
+        can2_a::identifier::{Can2A, IdCan2A},
+        can2_b::identifier::{Can2B, IdCan2B},
+        j1939::{
+            address::{Addr, DestinationAddr, SourceAddr},
+            identifier::{IdJ1939, J1939},
+            pgn::{CommunicationMode, GroupExtension, PduAssignment, PduFormat, Pgn},
+        },
+    };
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -13,7 +13,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::prelude::{Conversion, Data, Id, IsDataUnit, IsProtocol, Name, Pdu, J1939};
+use crate::{
+    conversion::Conversion,
+    identifier::{Id, IsProtocol},
+    payload::{Data, IsDataUnit, Name, Pdu},
+    protocol::j1939::identifier::J1939,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Message<P: IsProtocol, U: IsDataUnit> {

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -39,7 +39,7 @@ pub trait IsDataUnit {}
 /// | byte 7           | 8           |
 #[bitfield(u64, order = Msb)]
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-pub struct DataBitfield {
+pub struct Data {
     #[bits(8)]
     byte_0_bits: u8,
     #[bits(8)]
@@ -78,7 +78,7 @@ pub struct DataBitfield {
 /// | Identity number bits              | 21          |
 #[bitfield(u64, order = Msb)]
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-pub struct NameBitfield {
+pub struct Name {
     #[bits(1)]
     arbitrary_address_bits: bool,
     #[bits(3)]
@@ -101,12 +101,6 @@ pub struct NameBitfield {
     identity_number_bits: u32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Data(DataBitfield);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Name(NameBitfield);
-
 impl IsDataUnit for Data {}
 impl IsDataUnit for Name {}
 
@@ -119,21 +113,21 @@ impl Conversion<u64> for Pdu<Data> {
 
     /// Creates a new [`Data`] bitfield from a 64-bit integer.
     fn from_bits(bits: u64) -> Self {
-        Self(Data(DataBitfield(bits)))
+        Self(Data(bits))
     }
 
     /// Creates a new [`Data`] bitfield from a base-16 (hex) string slice.
     fn from_hex(hex_str: &str) -> Self {
         let bits = u64::from_str_radix(hex_str, 16).unwrap_or_default();
 
-        Self(Data(DataBitfield(bits)))
+        Self(Data(bits))
     }
 
     /// Creates a new [`Data`] bitfield from a 64-bit integer.
     /// # Errors
     /// - Never (conversion is trivial)
     fn try_from_bits(bits: u64) -> Result<Self, Self::Error> {
-        Ok(Self(Data(DataBitfield(bits))))
+        Ok(Self(Data(bits)))
     }
 
     /// Creates a new [`Data`] bitfield from a base-16 (hex) string slice.
@@ -142,12 +136,12 @@ impl Conversion<u64> for Pdu<Data> {
     fn try_from_hex(hex_str: &str) -> Result<Self, Self::Error> {
         let bits = u64::from_str_radix(hex_str, 16).map_err(anyhow::Error::msg)?;
 
-        Ok(Self(Data(DataBitfield(bits))))
+        Ok(Self(Data(bits)))
     }
 
     /// Creates a new 64-bit integer from the [`Data`] bitfield.
     fn into_bits(self) -> u64 {
-        self.0 .0.into_bits()
+        self.0.into_bits()
     }
 
     /// Creates a new base-16 (hex) [`String`] from the [`Data`] bitfield.
@@ -155,7 +149,7 @@ impl Conversion<u64> for Pdu<Data> {
     /// - `alloc`
     #[cfg(feature = "alloc")]
     fn into_hex(self) -> String {
-        format(format_args!("{:016X}", self.0 .0.into_bits()))
+        format(format_args!("{:016X}", self.0.into_bits()))
     }
 }
 
@@ -163,79 +157,79 @@ impl Pdu<Data> {
     /// Retrieve byte 0.
     #[must_use]
     pub const fn byte_0(self) -> u8 {
-        self.0 .0.byte_0_bits()
+        self.0.byte_0_bits()
     }
 
     /// Retrieve byte 1.
     #[must_use]
     pub const fn byte_1(self) -> u8 {
-        self.0 .0.byte_1_bits()
+        self.0.byte_1_bits()
     }
 
     /// Retrieve byte 2.
     #[must_use]
     pub const fn byte_2(self) -> u8 {
-        self.0 .0.byte_2_bits()
+        self.0.byte_2_bits()
     }
 
     /// Retrieve byte 3.
     #[must_use]
     pub const fn byte_3(self) -> u8 {
-        self.0 .0.byte_3_bits()
+        self.0.byte_3_bits()
     }
 
     /// Retrieve byte 4.
     #[must_use]
     pub const fn byte_4(self) -> u8 {
-        self.0 .0.byte_4_bits()
+        self.0.byte_4_bits()
     }
 
     /// Retrieve byte 5.
     #[must_use]
     pub const fn byte_5(self) -> u8 {
-        self.0 .0.byte_5_bits()
+        self.0.byte_5_bits()
     }
 
     /// Retrieve byte 6.
     #[must_use]
     pub const fn byte_6(self) -> u8 {
-        self.0 .0.byte_6_bits()
+        self.0.byte_6_bits()
     }
 
     /// Retrieve byte 7.
     #[must_use]
     pub const fn byte_7(self) -> u8 {
-        self.0 .0.byte_7_bits()
+        self.0.byte_7_bits()
     }
 
     /// Return the 64-bit [`Data`] bitfield as little-endian bytes.
     #[must_use]
     pub const fn to_le_bytes(&self) -> [u8; 8] {
-        self.0 .0.into_bits().to_le_bytes()
+        self.0.into_bits().to_le_bytes()
     }
 
     /// Return the 64-bit [`Data`] bitfield as big-endian bytes.
     #[must_use]
     pub const fn to_be_bytes(&self) -> [u8; 8] {
-        self.0 .0.into_bits().to_be_bytes()
+        self.0.into_bits().to_be_bytes()
     }
 
     /// Return the 64-bit [`Data`] bitfield as native-endian bytes.
     #[must_use]
     pub const fn to_ne_bytes(&self) -> [u8; 8] {
-        self.0 .0.into_bits().to_ne_bytes()
+        self.0.into_bits().to_ne_bytes()
     }
 
     /// Convert the [`Data`] bitfield to little-endian byte format.
     #[must_use]
     pub const fn to_le(&self) -> Self {
-        Self(Data(DataBitfield(self.0 .0.into_bits().to_le())))
+        Self(Data(self.0.into_bits().to_le()))
     }
 
     /// Convert the [`Data`] bitfield to big-endian byte format.
     #[must_use]
     pub const fn to_be(&self) -> Self {
-        Self(Data(DataBitfield(self.0 .0.into_bits().to_be())))
+        Self(Data(self.0.into_bits().to_be()))
     }
 }
 
@@ -244,21 +238,21 @@ impl Conversion<u64> for Pdu<Name> {
 
     /// Creates a new [`Name`] bitfield from a 64-bit integer.
     fn from_bits(bits: u64) -> Self {
-        Self(Name(NameBitfield(bits)))
+        Self(Name(bits))
     }
 
     /// Creates a new [`Name`] bitfield from a base-16 (hex) string slice.
     fn from_hex(hex_str: &str) -> Self {
         let bits = u64::from_str_radix(hex_str, 16).unwrap_or_default();
 
-        Self(Name(NameBitfield(bits)))
+        Self(Name(bits))
     }
 
     /// Creates a new [`Name`] bitfield from a 64-bit integer.
     /// # Errors
     /// - Never (conversion is trivial)
     fn try_from_bits(bits: u64) -> Result<Self, Self::Error> {
-        Ok(Self(Name(NameBitfield(bits))))
+        Ok(Self(Name(bits)))
     }
 
     /// Creates a new [`Name`] bitfield from a base-16 (hex) string slice.
@@ -268,12 +262,12 @@ impl Conversion<u64> for Pdu<Name> {
     fn try_from_hex(hex_str: &str) -> Result<Self, Self::Error> {
         let bits = u64::from_str_radix(hex_str, 16).map_err(anyhow::Error::msg)?;
 
-        Ok(Self(Name(NameBitfield(bits))))
+        Ok(Self(Name(bits)))
     }
 
     /// Creates a new 64-bit integer from the [`Name`] bitfield.
     fn into_bits(self) -> u64 {
-        self.0 .0.into_bits()
+        self.0.into_bits()
     }
 
     /// Creates a new base-16 (hex) [`String`] from the [`Name`] bitfield.
@@ -281,7 +275,7 @@ impl Conversion<u64> for Pdu<Name> {
     /// - `alloc`
     #[cfg(feature = "alloc")]
     fn into_hex(self) -> String {
-        format(format_args!("{:016X}", self.0 .0.into_bits()))
+        format(format_args!("{:016X}", self.0.into_bits()))
     }
 }
 
@@ -289,67 +283,67 @@ impl Pdu<Name> {
     /// Indicates whether or not the ECU/CA can negotiate an address (true = yes; false = no).
     #[must_use]
     pub const fn arbitrary_address(&self) -> bool {
-        self.0 .0.arbitrary_address_bits()
+        self.0.arbitrary_address_bits()
     }
 
     /// These codes are associated with particular industries such as on-highway equipment,
     /// agricultural equipment, and more.
     #[must_use]
     pub const fn industry_group(&self) -> u8 {
-        self.0 .0.industry_group_bits()
+        self.0.industry_group_bits()
     }
 
     /// Assigns a number to each instance on the Vehicle System (in case you connect several
     /// networks – e.g. connecting cars on a train).
     #[must_use]
     pub const fn vehicle_system_instance(&self) -> u8 {
-        self.0 .0.vehicle_system_instance_bits()
+        self.0.vehicle_system_instance_bits()
     }
 
     /// Vehicle systems are associated with the Industry Group and they can be, for instance,
     /// “tractor” in the “Common” industry or “trailer” in the “On-Highway” industry group.
     #[must_use]
     pub const fn vehicle_system(&self) -> u8 {
-        self.0 .0.vehicle_system_bits()
+        self.0.vehicle_system_bits()
     }
 
     /// Always zero(false).
     #[must_use]
     pub const fn reserved(&self) -> bool {
-        self.0 .0.reserved_bits()
+        self.0.reserved_bits()
     }
 
     /// This code, in a range between 128 and 255, is assigned according to the Industry Group. A
     /// value between 0 and 127 is not associated with any other parameter.
     #[must_use]
     pub const fn function(&self) -> u8 {
-        self.0 .0.function_bits()
+        self.0.function_bits()
     }
 
     /// Returns the function instance.
     #[must_use]
     pub const fn function_instance(&self) -> u8 {
-        self.0 .0.function_instance_bits()
+        self.0.function_instance_bits()
     }
 
     /// A J1939 network may accommodate several ECUs of the same kind (i.e. same functionality).
     /// The Instance code separates them.
     #[must_use]
     pub const fn ecu_instance(&self) -> u8 {
-        self.0 .0.ecu_instance_bits()
+        self.0.ecu_instance_bits()
     }
 
     /// The 11-Bit Manufacturer Code is assigned by the SAE.
     #[must_use]
     pub const fn manufacturer_code(&self) -> u16 {
-        self.0 .0.manufacturer_code_bits()
+        self.0.manufacturer_code_bits()
     }
 
     /// This field is assigned by the manufacturer, similar to a serial number, i.e. the code must
     /// be uniquely assigned to the unit.
     #[must_use]
     pub const fn identity_number(&self) -> u32 {
-        self.0 .0.identity_number_bits()
+        self.0.identity_number_bits()
     }
 }
 
@@ -368,21 +362,15 @@ mod data_tests {
 
         assert_eq!(18446606493475143679, data_a.into_bits());
 
-        assert_eq!(
-            Pdu::<Data>(Data(DataBitfield(18446743089616977919))),
-            data_a.to_be()
-        );
-        assert_eq!(
-            Pdu::<Data>(Data(DataBitfield(18446606493475143679))),
-            data_a.to_le()
-        );
+        assert_eq!(Pdu::<Data>(Data(18446743089616977919)), data_a.to_be());
+        assert_eq!(Pdu::<Data>(Data(18446606493475143679)), data_a.to_le());
 
         Ok(())
     }
 
     #[test]
     fn test_name_bitfield() {
-        let name_a = NameBitfield::new()
+        let name_a = Name::new()
             .with_arbitrary_address_bits(true)
             .with_industry_group_bits(0)
             .with_vehicle_system_instance_bits(0x5)

--- a/src/protocol/can2_a/identifier.rs
+++ b/src/protocol/can2_a/identifier.rs
@@ -6,7 +6,7 @@ use bitfield_struct::bitfield;
 
 use crate::{
     conversion::Conversion,
-    prelude::{Id, IsProtocol},
+    identifier::{Id, IsProtocol},
 };
 
 /// Bitfield representation of a standard 11-bit CAN identifier.
@@ -28,15 +28,17 @@ pub struct Can2A {
 
 impl IsProtocol for Can2A {}
 
-impl Conversion<u16> for Id<Can2A> {
+pub type IdCan2A = Id<Can2A>;
+
+impl Conversion<u16> for IdCan2A {
     type Error = anyhow::Error;
 
     /// Creates a new 11-bit standard identifier from a 16-bit integer.
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2A, Conversion};
-    /// let id_a = Id::<Can2A>::from_bits(15);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2A::from_bits(15);
     ///
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// ```
@@ -50,8 +52,8 @@ impl Conversion<u16> for Id<Can2A> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2A, Conversion};
-    /// let id_a = Id::<Can2A>::from_hex("00F");
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2A::from_hex("00F");
     ///
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// ```
@@ -68,9 +70,9 @@ impl Conversion<u16> for Id<Can2A> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2A, Conversion};
-    /// let id_a = Id::<Can2A>::try_from_bits(15).unwrap();
-    /// let id_b = Id::<Can2A>::try_from_bits(2048);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2A::try_from_bits(15).unwrap();
+    /// let id_b = IdCan2A::try_from_bits(2048);
     ///
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// assert!(id_b.is_err());
@@ -94,9 +96,9 @@ impl Conversion<u16> for Id<Can2A> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2A, Conversion};
-    /// let id_a = Id::<Can2A>::try_from_hex("00F").unwrap();
-    /// let id_b = Id::<Can2A>::try_from_hex("FFF");
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2A::try_from_hex("00F").unwrap();
+    /// let id_b = IdCan2A::try_from_hex("FFF");
     ///
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// assert!(id_b.is_err());
@@ -117,8 +119,8 @@ impl Conversion<u16> for Id<Can2A> {
     /// Creates a new 16-bit integer from the 11-bit standard identifier.
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2A, Conversion};
-    /// let id_a = Id::<Can2A>::from_bits(15);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2A::from_bits(15);
     ///
     /// assert_eq!(15, id_a.into_bits());
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
@@ -135,8 +137,8 @@ impl Conversion<u16> for Id<Can2A> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2A, Conversion};
-    /// let id_a = Id::<Can2A>::from_bits(15);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2A::from_bits(15);
     ///
     /// assert_eq!("00F", id_a.into_hex());
     /// ```
@@ -148,28 +150,27 @@ impl Conversion<u16> for Id<Can2A> {
 
 #[cfg(test)]
 mod can2a_tests {
-    use crate::prelude::{Conversion, Id};
 
-    use super::Can2A;
+    use super::*;
 
     #[test]
     fn test_from_bits() {
-        let id_a = Id::<Can2A>::from_bits(15);
+        let id_a = IdCan2A::from_bits(15);
 
         assert_eq!(0b000_0000_1111, id_a.0 .0)
     }
 
     #[test]
     fn test_from_hex() {
-        let id_a = Id::<Can2A>::from_hex("00F");
+        let id_a = IdCan2A::from_hex("00F");
 
         assert_eq!(0b000_0000_1111, id_a.0 .0)
     }
 
     #[test]
     fn test_try_from_bits() {
-        let id_a = Id::<Can2A>::try_from_bits(15).unwrap();
-        let id_b = Id::<Can2A>::try_from_bits(2048);
+        let id_a = IdCan2A::try_from_bits(15).unwrap();
+        let id_b = IdCan2A::try_from_bits(2048);
 
         assert_eq!(0b000_0000_1111, id_a.0 .0);
         assert!(id_b.is_err())
@@ -177,8 +178,8 @@ mod can2a_tests {
 
     #[test]
     fn test_try_from_hex() {
-        let id_a = Id::<Can2A>::try_from_hex("00F").unwrap();
-        let id_b = Id::<Can2A>::try_from_hex("FFF");
+        let id_a = IdCan2A::try_from_hex("00F").unwrap();
+        let id_b = IdCan2A::try_from_hex("FFF");
 
         assert_eq!(0b000_0000_1111, id_a.0 .0);
         assert!(id_b.is_err())
@@ -186,7 +187,7 @@ mod can2a_tests {
 
     #[test]
     fn test_into_bits() {
-        let id_a = Id::<Can2A>::from_bits(15);
+        let id_a = IdCan2A::from_bits(15);
 
         assert_eq!(15, id_a.into_bits())
     }
@@ -194,7 +195,7 @@ mod can2a_tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_into_hex() {
-        let id_a = Id::<Can2A>::from_bits(15);
+        let id_a = IdCan2A::from_bits(15);
 
         assert_eq!("00F", id_a.into_hex())
     }

--- a/src/protocol/can2_a/mod.rs
+++ b/src/protocol/can2_a/mod.rs
@@ -1,3 +1,1 @@
-mod identifier;
-
-pub use identifier::*;
+pub mod identifier;

--- a/src/protocol/can2_b/identifier.rs
+++ b/src/protocol/can2_b/identifier.rs
@@ -6,7 +6,7 @@ use bitfield_struct::bitfield;
 
 use crate::{
     conversion::Conversion,
-    prelude::{Id, IsProtocol},
+    identifier::{Id, IsProtocol},
 };
 
 /// Bitfield representation of an extended 29-bit CAN identifier.
@@ -28,15 +28,17 @@ pub struct Can2B {
 
 impl IsProtocol for Can2B {}
 
-impl Conversion<u32> for Id<Can2B> {
+pub type IdCan2B = Id<Can2B>;
+
+impl Conversion<u32> for IdCan2B {
     type Error = anyhow::Error;
 
     /// Creates a new 29-bit extended identifier from a 16-bit integer.
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2B, Conversion};
-    /// let id_a = Id::<Can2B>::from_bits(16711935);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2B::from_bits(16711935);
     ///
     /// assert_eq!(0b00000_11111111_00000000_11111111, id_a.into_bits());
     /// ```
@@ -50,8 +52,8 @@ impl Conversion<u32> for Id<Can2B> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2B, Conversion};
-    /// let id_a = Id::<Can2B>::from_hex("00FF00FF");
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2B::from_hex("00FF00FF");
     ///
     /// assert_eq!(0b00000_11111111_00000000_11111111, id_a.into_bits());
     /// ```
@@ -69,9 +71,9 @@ impl Conversion<u32> for Id<Can2B> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2B, Conversion};
-    /// let id_a = Id::<Can2B>::try_from_bits(16711935).unwrap();
-    /// let id_b = Id::<Can2B>::try_from_bits(536870912);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2B::try_from_bits(16711935).unwrap();
+    /// let id_b = IdCan2B::try_from_bits(536870912);
     ///
     /// assert_eq!(0b00000_11111111_00000000_11111111, id_a.into_bits());
     /// assert!(id_b.is_err());
@@ -96,9 +98,9 @@ impl Conversion<u32> for Id<Can2B> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2B, Conversion};
-    /// let id_a = Id::<Can2B>::try_from_hex("00FF00FF").unwrap();
-    /// let id_b = Id::<Can2B>::try_from_hex("20000000");
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2B::try_from_hex("00FF00FF").unwrap();
+    /// let id_b = IdCan2B::try_from_hex("20000000");
     ///
     /// assert_eq!(0b00000_11111111_00000000_11111111, id_a.into_bits());
     /// assert!(id_b.is_err());
@@ -120,8 +122,8 @@ impl Conversion<u32> for Id<Can2B> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2B, Conversion};
-    /// let id_a = Id::<Can2B>::from_bits(16711935);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2B::from_bits(16711935);
     ///
     /// assert_eq!(16711935, id_a.into_bits());
     /// ```
@@ -136,8 +138,8 @@ impl Conversion<u32> for Id<Can2B> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, Can2B, Conversion};
-    /// let id_a = Id::<Can2B>::from_bits(16711935);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdCan2B::from_bits(16711935);
     ///
     /// assert_eq!("00FF00FF", id_a.into_hex());
     /// ```
@@ -149,28 +151,27 @@ impl Conversion<u32> for Id<Can2B> {
 
 #[cfg(test)]
 mod can2b_tests {
-    use crate::prelude::{Conversion, Id};
 
-    use super::Can2B;
+    use super::*;
 
     #[test]
     fn test_from_bits() {
-        let id_a = Id::<Can2B>::from_bits(16711935);
+        let id_a = IdCan2B::from_bits(16711935);
 
         assert_eq!(0b00000_11111111_00000000_11111111, id_a.0 .0)
     }
 
     #[test]
     fn test_from_hex() {
-        let id_a = Id::<Can2B>::from_hex("00FF00FF");
+        let id_a = IdCan2B::from_hex("00FF00FF");
 
         assert_eq!(0b00000_11111111_00000000_11111111, id_a.0 .0)
     }
 
     #[test]
     fn test_try_from_bits() {
-        let id_a = Id::<Can2B>::try_from_bits(16711935).unwrap();
-        let id_b = Id::<Can2B>::try_from_bits(536870912);
+        let id_a = IdCan2B::try_from_bits(16711935).unwrap();
+        let id_b = IdCan2B::try_from_bits(536870912);
 
         assert_eq!(0b00000_11111111_00000000_11111111, id_a.0 .0);
         assert!(id_b.is_err())
@@ -178,8 +179,8 @@ mod can2b_tests {
 
     #[test]
     fn test_try_from_hex() {
-        let id_a = Id::<Can2B>::try_from_hex("00FF00FF").unwrap();
-        let id_b = Id::<Can2B>::try_from_hex("20000000");
+        let id_a = IdCan2B::try_from_hex("00FF00FF").unwrap();
+        let id_b = IdCan2B::try_from_hex("20000000");
 
         assert_eq!(0b00000_11111111_00000000_11111111, id_a.0 .0);
         assert!(id_b.is_err())
@@ -187,7 +188,7 @@ mod can2b_tests {
 
     #[test]
     fn test_into_bits() {
-        let id_a = Id::<Can2B>::from_bits(16711935);
+        let id_a = IdCan2B::from_bits(16711935);
 
         assert_eq!(16711935, id_a.into_bits())
     }
@@ -195,7 +196,7 @@ mod can2b_tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_into_hex() {
-        let id_a = Id::<Can2B>::from_bits(16711935);
+        let id_a = IdCan2B::from_bits(16711935);
 
         assert_eq!("00FF00FF", id_a.into_hex())
     }

--- a/src/protocol/can2_b/mod.rs
+++ b/src/protocol/can2_b/mod.rs
@@ -1,3 +1,1 @@
-mod identifier;
-
-pub use identifier::*;
+pub mod identifier;

--- a/src/protocol/j1939/identifier.rs
+++ b/src/protocol/j1939/identifier.rs
@@ -6,7 +6,7 @@ use bitfield_struct::bitfield;
 
 use crate::{
     conversion::Conversion,
-    prelude::{Id, IsProtocol},
+    identifier::{Id, IsProtocol},
 };
 
 use super::address::SourceAddr;
@@ -45,16 +45,18 @@ pub struct J1939 {
 
 impl IsProtocol for J1939 {}
 
-impl Conversion<u32> for Id<J1939> {
+pub type IdJ1939 = Id<J1939>;
+
+impl Conversion<u32> for IdJ1939 {
     type Error = anyhow::Error;
 
     /// Creates a new 29-bit J1939 identifier from a 32-bit integer.
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, J1939, Conversion};
-    /// let id_a = Id::<J1939>::from_bits(0);
-    /// let id_b = Id::<J1939>::from_bits(4294967295);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdJ1939::from_bits(0);
+    /// let id_b = IdJ1939::from_bits(4294967295);
     ///
     /// assert_eq!(0b000_000_0_0_00000000_00000000_00000000, id_a.into_bits());
     /// assert_eq!(0b111_111_1_1_11111111_11111111_11111111, id_b.into_bits());
@@ -68,10 +70,10 @@ impl Conversion<u32> for Id<J1939> {
     /// Creates a new 29-bit J1939 identifier from a base-16 (hex) string slice.
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, J1939, Conversion};
+    /// # use can_types::prelude::*;
     /// let hex_str = "0CF00400";
     ///
-    /// let id_a = Id::<J1939>::from_hex(hex_str);
+    /// let id_a = IdJ1939::from_hex(hex_str);
     ///
     /// assert_eq!(0b000_011_0_0_11110000_00000100_00000000, id_a.into_bits());
     /// assert_eq!(217056256, id_a.into_bits());
@@ -90,9 +92,9 @@ impl Conversion<u32> for Id<J1939> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, J1939, Conversion};
-    /// let id_a = Id::<J1939>::try_from_bits(0);
-    /// let id_b = Id::<J1939>::try_from_bits(4294967295);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdJ1939::try_from_bits(0);
+    /// let id_b = IdJ1939::try_from_bits(4294967295);
     ///
     /// assert_eq!(0b000_000_0_0_00000000_00000000_00000000, id_a.unwrap().into_bits());
     /// assert!(id_b.is_err());
@@ -117,9 +119,9 @@ impl Conversion<u32> for Id<J1939> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, J1939, Conversion};
-    /// let id_a = Id::<J1939>::try_from_hex("00FF00FF").unwrap();
-    /// let id_b = Id::<J1939>::try_from_hex("20000000");
+    /// # use can_types::prelude::*;
+    /// let id_a = IdJ1939::try_from_hex("00FF00FF").unwrap();
+    /// let id_b = IdJ1939::try_from_hex("20000000");
     ///
     /// assert_eq!(0b000_0_0_11111111_00000000_11111111, id_a.into_bits());
     /// assert!(id_b.is_err())
@@ -141,8 +143,8 @@ impl Conversion<u32> for Id<J1939> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, J1939, Conversion};
-    /// let id_a = Id::<J1939>::from_bits(0);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdJ1939::from_bits(0);
     ///
     /// assert_eq!(0, id_a.into_bits());
     /// ```
@@ -157,8 +159,8 @@ impl Conversion<u32> for Id<J1939> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, J1939, Conversion};
-    /// let id_a = Id::<J1939>::from_bits(15);
+    /// # use can_types::prelude::*;
+    /// let id_a = IdJ1939::from_bits(15);
     ///
     /// assert_eq!("0000000F", id_a.into_hex());
     /// ```
@@ -168,7 +170,7 @@ impl Conversion<u32> for Id<J1939> {
     }
 }
 
-impl Id<J1939> {
+impl IdJ1939 {
     /// Decomposes the 29-bit J1939 identifier into its raw parts.
     ///
     /// Returns a tuple containing the priority, reserved flag, data page flag,
@@ -176,8 +178,8 @@ impl Id<J1939> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, J1939, Conversion};
-    /// let id_a = Id::<J1939>::from_hex("00FF00FF");
+    /// # use can_types::prelude::*;
+    /// let id_a = IdJ1939::from_hex("00FF00FF");
     ///
     /// let (p, r, dp, pf, ps, sa) = id_a.into_raw_parts();
     /// ```
@@ -208,10 +210,10 @@ impl Id<J1939> {
     ///
     /// # Examples
     /// ```rust
-    /// # use can_types::prelude::{Id, J1939, Conversion};
-    /// let expected_id = Id::<J1939>::from_hex("00FF00FF");
+    /// # use can_types::prelude::*;
+    /// let expected_id = IdJ1939::from_hex("00FF00FF");
     ///
-    /// let id_a = Id::<J1939>::from_raw_parts(0x0, false, false, 0xFF, 0x00, 0xFF);
+    /// let id_a = IdJ1939::from_raw_parts(0x0, false, false, 0xFF, 0x00, 0xFF);
     ///
     /// assert_eq!(expected_id, id_a.unwrap());
     /// ```
@@ -282,28 +284,27 @@ impl Id<J1939> {
 
 #[cfg(test)]
 mod j1939_tests {
-    use crate::prelude::{Conversion, Id};
 
-    use super::J1939;
+    use super::*;
 
     #[test]
     fn test_from_bits() {
-        let id_a = Id::<J1939>::from_bits(16711935);
+        let id_a = IdJ1939::from_bits(16711935);
 
         assert_eq!(0b000_0_0_11111111_00000000_11111111, id_a.0 .0)
     }
 
     #[test]
     fn test_from_hex() {
-        let id_a = Id::<J1939>::from_hex("00FF00FF");
+        let id_a = IdJ1939::from_hex("00FF00FF");
 
         assert_eq!(0b000_0_0_11111111_00000000_11111111, id_a.0 .0)
     }
 
     #[test]
     fn test_try_from_bits() {
-        let id_a = Id::<J1939>::try_from_bits(16711935).unwrap();
-        let id_b = Id::<J1939>::try_from_bits(536870912);
+        let id_a = IdJ1939::try_from_bits(16711935).unwrap();
+        let id_b = IdJ1939::try_from_bits(536870912);
 
         assert_eq!(0b000_0_0_11111111_00000000_11111111, id_a.0 .0);
         assert!(id_b.is_err())
@@ -311,8 +312,8 @@ mod j1939_tests {
 
     #[test]
     fn test_try_from_hex() {
-        let id_a = Id::<J1939>::try_from_hex("00FF00FF").unwrap();
-        let id_b = Id::<J1939>::try_from_hex("20000000");
+        let id_a = IdJ1939::try_from_hex("00FF00FF").unwrap();
+        let id_b = IdJ1939::try_from_hex("20000000");
 
         assert_eq!(0b000_0_0_11111111_00000000_11111111, id_a.0 .0);
         assert!(id_b.is_err())
@@ -320,7 +321,7 @@ mod j1939_tests {
 
     #[test]
     fn test_into_bits() {
-        let id_a = Id::<J1939>::from_bits(16711935);
+        let id_a = IdJ1939::from_bits(16711935);
 
         assert_eq!(16711935, id_a.into_bits())
     }
@@ -328,7 +329,7 @@ mod j1939_tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn test_into_hex() {
-        let id_a = Id::<J1939>::from_bits(16711935);
+        let id_a = IdJ1939::from_bits(16711935);
 
         assert_eq!("00FF00FF", id_a.into_hex())
     }

--- a/src/protocol/j1939/mod.rs
+++ b/src/protocol/j1939/mod.rs
@@ -1,7 +1,3 @@
-mod address;
-mod identifier;
-mod pgn;
-
-pub use address::*;
-pub use identifier::*;
-pub use pgn::*;
+pub mod address;
+pub mod identifier;
+pub mod pgn;

--- a/src/protocol/j1939/pgn.rs
+++ b/src/protocol/j1939/pgn.rs
@@ -19,10 +19,9 @@ if_alloc! {
 
 use bitfield_struct::bitfield;
 
-use crate::{
-    conversion::Conversion, identifier::Id, protocol::j1939::address::DestinationAddr,
-    protocol::j1939::identifier::J1939,
-};
+use crate::{conversion::Conversion, identifier::Id, protocol::j1939::identifier::J1939};
+
+use super::address::DestinationAddr;
 
 /// Represents the assignment type of a Protocol Data Unit (PDU).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,7 +1,3 @@
-mod can2_a;
-mod can2_b;
-mod j1939;
-
-pub use can2_a::*;
-pub use can2_b::*;
-pub use j1939::*;
+pub mod can2_a;
+pub mod can2_b;
+pub mod j1939;


### PR DESCRIPTION
Added convenient aliases for the ID types to make "turbofish" syntax optional. Changed the visibility of most modules so that the imports may be granular as opposed to the prelude idiom. The prelude glob import is still an option for a very clean and simple import of all relevant types, however, I chose not to include the prelude module in the docs as it's just a  re-export.