### PR TITLE
Implemented removal of conversion derive

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -35,6 +35,7 @@ impl Message<J1939, Data> {
     ///
     /// # Returns
     /// A new [`Message`] instance initialized with the provided parts.
+    #[inline]
     #[must_use]
     pub fn from_parts(id: Id<J1939>, pdu: Pdu<Data>) -> Self {
         Self { id, pdu }
@@ -46,6 +47,7 @@ impl Message<J1939, Data> {
     /// A tuple containing:
     /// - An [`Id<J1939>`] representing the 29-bit identifier.
     /// - A [`Pdu<Data>`] containing the payload or content of the message.
+    #[inline]
     #[must_use]
     pub fn into_parts(self) -> (Id<J1939>, Pdu<Data>) {
         (self.id, self.pdu)
@@ -55,6 +57,7 @@ impl Message<J1939, Data> {
     /// # Errors
     /// - If failed to construct the identifier field from bits
     /// - If failed to construct the pdu field from bits
+    #[inline]
     pub fn try_from_bits(hex_id: u32, hex_pdu: u64) -> Result<Self, anyhow::Error> {
         let id = Id::<J1939>::from_bits(hex_id);
         let pdu = Pdu::<Data>::try_from_bits(hex_pdu)?;
@@ -66,6 +69,7 @@ impl Message<J1939, Data> {
     /// # Errors
     /// - If failed to construct the identifier field from hex
     /// - If failed to construct the pdu field from hex
+    #[inline]
     pub fn try_from_hex(hex_id: &str, hex_pdu: &str) -> Result<Self, anyhow::Error> {
         let id = Id::<J1939>::try_from_hex(hex_id)?;
         let pdu = Pdu::<Data>::try_from_hex(hex_pdu)?;
@@ -81,6 +85,7 @@ impl Message<J1939, Data> {
     ///
     /// # Returns
     /// A new [`Message`] instance initialized with the decoded components.
+    #[inline]
     #[must_use]
     pub fn from_bits(hex_id: u32, hex_pdu: u64) -> Self {
         let id = Id::<J1939>::from_bits(hex_id);
@@ -97,6 +102,7 @@ impl Message<J1939, Data> {
     ///
     /// # Returns
     /// A new [`Message`] instance initialized with the decoded components.
+    #[inline]
     #[must_use]
     pub fn from_hex(hex_id: &str, hex_pdu: &str) -> Self {
         let id = Id::<J1939>::from_hex(hex_id);
@@ -109,6 +115,7 @@ impl Message<J1939, Data> {
     ///
     /// # Returns
     /// The [`Id<J1939>`] bitfield associated with the message.
+    #[inline]
     #[must_use]
     pub fn id(&self) -> Id<J1939> {
         self.id
@@ -118,6 +125,7 @@ impl Message<J1939, Data> {
     ///
     /// # Returns
     /// The [`Pdu<Data>`] bitfield associated with the message.
+    #[inline]
     #[must_use]
     pub fn pdu(&self) -> Pdu<Data> {
         self.pdu
@@ -133,6 +141,7 @@ impl Message<J1939, Name> {
     ///
     /// # Returns
     /// A new [`Message`] instance initialized with the provided parts.
+    #[inline]
     #[must_use]
     pub fn from_parts(id: Id<J1939>, pdu: Pdu<Name>) -> Self {
         Self { id, pdu }
@@ -144,6 +153,7 @@ impl Message<J1939, Name> {
     /// A tuple containing:
     /// - An [`Id<J1939>`] representing the 29-bit identifier.
     /// - A [`Pdu<Data>`] containing the payload or content of the message.
+    #[inline]
     #[must_use]
     pub fn into_parts(self) -> (Id<J1939>, Pdu<Name>) {
         (self.id, self.pdu)
@@ -153,6 +163,7 @@ impl Message<J1939, Name> {
     /// # Errors
     /// - If failed to construct the identifier field from bits
     /// - If failed to construct the pdu field from bits
+    #[inline]
     pub fn try_from_bits(hex_id: u32, hex_pdu: u64) -> Result<Self, anyhow::Error> {
         let id = Id::<J1939>::try_from_bits(hex_id)?;
         let pdu = Pdu::<Name>::try_from_bits(hex_pdu)?;
@@ -164,6 +175,7 @@ impl Message<J1939, Name> {
     /// # Errors
     /// - If failed to construct the identifier field from hex
     /// - If failed to construct the pdu field from hex
+    #[inline]
     pub fn try_from_hex(hex_id: &str, hex_pdu: &str) -> Result<Self, anyhow::Error> {
         let id = Id::<J1939>::try_from_hex(hex_id)?;
         let pdu = Pdu::<Name>::try_from_hex(hex_pdu)?;
@@ -179,6 +191,7 @@ impl Message<J1939, Name> {
     ///
     /// # Returns
     /// A new [`Message`] instance initialized with the decoded components.
+    #[inline]
     #[must_use]
     pub fn from_bits(hex_id: u32, hex_pdu: u64) -> Self {
         let id = Id::<J1939>::from_bits(hex_id);
@@ -195,6 +208,7 @@ impl Message<J1939, Name> {
     ///
     /// # Returns
     /// A new [`Message`] instance initialized with the decoded components.
+    #[inline]
     #[must_use]
     pub fn from_hex(hex_id: &str, hex_pdu: &str) -> Self {
         let id = Id::<J1939>::from_hex(hex_id);
@@ -207,6 +221,7 @@ impl Message<J1939, Name> {
     ///
     /// # Returns
     /// The [`Id<J1939>`] bitfield associated with the message.
+    #[inline]
     #[must_use]
     pub fn id(&self) -> Id<J1939> {
         self.id
@@ -216,6 +231,7 @@ impl Message<J1939, Name> {
     ///
     /// # Returns
     /// The [`Pdu<Data>`] bitfield associated with the message.
+    #[inline]
     #[must_use]
     pub fn pdu(&self) -> Pdu<Name> {
         self.pdu

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -37,7 +37,7 @@ pub trait IsDataUnit {}
 /// | byte 5           | 8           |
 /// | byte 6           | 8           |
 /// | byte 7           | 8           |
-#[bitfield(u64, order = Msb)]
+#[bitfield(u64, order = Msb, conversion = false)]
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct Data {
     #[bits(8)]
@@ -76,7 +76,7 @@ pub struct Data {
 /// | ECU instance bits                 | 3           |
 /// | Manufacturer code bits            | 11          |
 /// | Identity number bits              | 21          |
-#[bitfield(u64, order = Msb)]
+#[bitfield(u64, order = Msb, conversion = false)]
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct Name {
     #[bits(1)]
@@ -141,7 +141,7 @@ impl Conversion<u64> for Pdu<Data> {
 
     /// Creates a new 64-bit integer from the [`Data`] bitfield.
     fn into_bits(self) -> u64 {
-        self.0.into_bits()
+        self.0 .0
     }
 
     /// Creates a new base-16 (hex) [`String`] from the [`Data`] bitfield.
@@ -149,7 +149,7 @@ impl Conversion<u64> for Pdu<Data> {
     /// - `alloc`
     #[cfg(feature = "alloc")]
     fn into_hex(self) -> String {
-        format(format_args!("{:016X}", self.0.into_bits()))
+        format(format_args!("{:016X}", self.0 .0))
     }
 }
 
@@ -205,31 +205,31 @@ impl Pdu<Data> {
     /// Return the 64-bit [`Data`] bitfield as little-endian bytes.
     #[must_use]
     pub const fn to_le_bytes(&self) -> [u8; 8] {
-        self.0.into_bits().to_le_bytes()
+        self.0 .0.to_le_bytes()
     }
 
     /// Return the 64-bit [`Data`] bitfield as big-endian bytes.
     #[must_use]
     pub const fn to_be_bytes(&self) -> [u8; 8] {
-        self.0.into_bits().to_be_bytes()
+        self.0 .0.to_be_bytes()
     }
 
     /// Return the 64-bit [`Data`] bitfield as native-endian bytes.
     #[must_use]
     pub const fn to_ne_bytes(&self) -> [u8; 8] {
-        self.0.into_bits().to_ne_bytes()
+        self.0 .0.to_ne_bytes()
     }
 
     /// Convert the [`Data`] bitfield to little-endian byte format.
     #[must_use]
     pub const fn to_le(&self) -> Self {
-        Self(Data(self.0.into_bits().to_le()))
+        Self(Data(self.0 .0.to_le()))
     }
 
     /// Convert the [`Data`] bitfield to big-endian byte format.
     #[must_use]
     pub const fn to_be(&self) -> Self {
-        Self(Data(self.0.into_bits().to_be()))
+        Self(Data(self.0 .0.to_be()))
     }
 }
 
@@ -267,7 +267,7 @@ impl Conversion<u64> for Pdu<Name> {
 
     /// Creates a new 64-bit integer from the [`Name`] bitfield.
     fn into_bits(self) -> u64 {
-        self.0.into_bits()
+        self.0 .0
     }
 
     /// Creates a new base-16 (hex) [`String`] from the [`Name`] bitfield.
@@ -275,7 +275,7 @@ impl Conversion<u64> for Pdu<Name> {
     /// - `alloc`
     #[cfg(feature = "alloc")]
     fn into_hex(self) -> String {
-        format(format_args!("{:016X}", self.0.into_bits()))
+        format(format_args!("{:016X}", self.0 .0))
     }
 }
 
@@ -382,8 +382,10 @@ mod data_tests {
             .with_manufacturer_code_bits(0x122)
             .with_identity_number_bits(0xB0309);
 
+        let pdu_name = Pdu::<Name>(name_a);
+
         let bytes_a: [u8; 8] = [0x09, 0x03, 0x4B, 0x24, 0x11, 0x05, 0x0C, 0x85];
-        let name_a_bytes = name_a.into_bits().to_le_bytes();
+        let name_a_bytes = pdu_name.into_bits().to_le_bytes();
 
         assert_eq!(bytes_a, name_a_bytes);
     }

--- a/src/protocol/can2_a/identifier.rs
+++ b/src/protocol/can2_a/identifier.rs
@@ -17,11 +17,11 @@ use crate::{
 /// |------------------------|-------------|
 /// | Padding bits (private) | 5           |
 /// | Identifier bits        | 11          |
-#[bitfield(u16, order = Msb)]
+#[bitfield(u16, order = Msb, conversion = false)]
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct Can2A {
     #[bits(5)]
-    _padding_bits: u8,
+    __: u8,
     #[bits(11)]
     id_bits: u16,
 }
@@ -31,7 +31,8 @@ impl IsProtocol for Can2A {}
 pub type IdCan2A = Id<Can2A>;
 
 impl IdCan2A {
-    /// Returns the value of the identifier, which is truncated to 11-bits. 
+    /// Returns the value of the identifier, which is truncated to 11-bits.
+    #[inline]
     #[must_use]
     pub const fn id(self) -> u16 {
         self.0.id_bits()
@@ -50,6 +51,7 @@ impl Conversion<u16> for IdCan2A {
     ///
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// ```
+    #[inline]
     fn from_bits(bits: u16) -> Self {
         let id_bitfield = Can2A(bits);
 
@@ -65,6 +67,7 @@ impl Conversion<u16> for IdCan2A {
     ///
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// ```
+    #[inline]
     fn from_hex(hex_str: &str) -> Self {
         let bits = u16::from_str_radix(hex_str, 16).unwrap_or_default();
         let id_bitfield = Can2A(bits);
@@ -85,6 +88,7 @@ impl Conversion<u16> for IdCan2A {
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// assert!(id_b.is_err());
     /// ```
+    #[inline]
     fn try_from_bits(bits: u16) -> Result<Self, Self::Error> {
         if bits > 0x7FF {
             return Err(anyhow::anyhow!(
@@ -111,6 +115,7 @@ impl Conversion<u16> for IdCan2A {
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// assert!(id_b.is_err());
     /// ```
+    #[inline]
     fn try_from_hex(hex_str: &str) -> Result<Self, Self::Error> {
         let bits = u16::from_str_radix(hex_str, 16).map_err(anyhow::Error::msg)?;
         if bits > 0x7FF {
@@ -134,8 +139,9 @@ impl Conversion<u16> for IdCan2A {
     /// assert_eq!(0b000_0000_1111, id_a.into_bits());
     /// assert_eq!(0x00F, id_a.into_bits());
     /// ```
+    #[inline]
     fn into_bits(self) -> u16 {
-        self.0.into_bits()
+        self.0 .0
     }
 
     /// Creates a new base-16 (hex) `String` from the 11-bit standard identifier.
@@ -150,9 +156,10 @@ impl Conversion<u16> for IdCan2A {
     ///
     /// assert_eq!("00F", id_a.into_hex());
     /// ```
+    #[inline]
     #[cfg(feature = "alloc")]
     fn into_hex(self) -> String {
-        format(format_args!("{:03X}", self.0.into_bits()))
+        format(format_args!("{:03X}", self.0 .0))
     }
 }
 
@@ -164,7 +171,7 @@ mod can2a_tests {
     #[test]
     fn test_identifier_value() {
         let id_a = IdCan2A::from_bits(u16::MAX);
-        
+
         assert_eq!(0x7FF, id_a.id())
     }
 

--- a/src/protocol/can2_b/identifier.rs
+++ b/src/protocol/can2_b/identifier.rs
@@ -17,11 +17,11 @@ use crate::{
 /// |------------------------|-------------|
 /// | Padding bits (private) | 3           |
 /// | Identifier bits        | 29          |
-#[bitfield(u32, order = Msb)]
+#[bitfield(u32, order = Msb, conversion = false)]
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct Can2B {
     #[bits(3)]
-    _padding_bits: u8,
+    __: u8,
     #[bits(29)]
     id_bits: u32,
 }
@@ -31,7 +31,8 @@ impl IsProtocol for Can2B {}
 pub type IdCan2B = Id<Can2B>;
 
 impl IdCan2B {
-    /// Returns the value of the identifier, which is truncated to 29-bits. 
+    /// Returns the value of the identifier, which is truncated to 29-bits.
+    #[inline]
     #[must_use]
     pub const fn id(self) -> u32 {
         self.0.id_bits()
@@ -50,6 +51,7 @@ impl Conversion<u32> for IdCan2B {
     ///
     /// assert_eq!(0b00000_11111111_00000000_11111111, id_a.into_bits());
     /// ```
+    #[inline]
     fn from_bits(bits: u32) -> Self {
         let id_bitfield = Can2B(bits);
 
@@ -65,6 +67,7 @@ impl Conversion<u32> for IdCan2B {
     ///
     /// assert_eq!(0b00000_11111111_00000000_11111111, id_a.into_bits());
     /// ```
+    #[inline]
     fn from_hex(hex_str: &str) -> Self {
         let bits = u32::from_str_radix(hex_str, 16).unwrap_or_default();
         let id_bitfield = Can2B(bits);
@@ -86,6 +89,7 @@ impl Conversion<u32> for IdCan2B {
     /// assert_eq!(0b00000_11111111_00000000_11111111, id_a.into_bits());
     /// assert!(id_b.is_err());
     /// ```
+    #[inline]
     fn try_from_bits(bits: u32) -> Result<Self, Self::Error> {
         if bits > 0x1FFF_FFFF {
             return Err(anyhow::anyhow!(
@@ -113,6 +117,7 @@ impl Conversion<u32> for IdCan2B {
     /// assert_eq!(0b00000_11111111_00000000_11111111, id_a.into_bits());
     /// assert!(id_b.is_err());
     /// ```
+    #[inline]
     fn try_from_hex(hex_str: &str) -> Result<Self, Self::Error> {
         let bits = u32::from_str_radix(hex_str, 16).map_err(anyhow::Error::msg)?;
         if bits > 0x1FFF_FFFF {
@@ -135,8 +140,9 @@ impl Conversion<u32> for IdCan2B {
     ///
     /// assert_eq!(16711935, id_a.into_bits());
     /// ```
+    #[inline]
     fn into_bits(self) -> u32 {
-        self.0.into_bits()
+        self.0 .0
     }
 
     /// Creates a new base-16 (hex) `String` from the 29-bit extended identifier.
@@ -151,9 +157,10 @@ impl Conversion<u32> for IdCan2B {
     ///
     /// assert_eq!("00FF00FF", id_a.into_hex());
     /// ```
+    #[inline]
     #[cfg(feature = "alloc")]
     fn into_hex(self) -> String {
-        format(format_args!("{:08X}", self.0.into_bits()))
+        format(format_args!("{:08X}", self.0 .0))
     }
 }
 
@@ -165,7 +172,7 @@ mod can2b_tests {
     #[test]
     fn test_identifier_value() {
         let id_a = IdCan2B::from_bits(u32::MAX);
-        
+
         assert_eq!(0x1FFFFFFF, id_a.id())
     }
 

--- a/src/protocol/j1939/identifier.rs
+++ b/src/protocol/j1939/identifier.rs
@@ -28,7 +28,7 @@ use super::address::SourceAddr;
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct J1939 {
     #[bits(3)]
-    _padding_bits: u8,
+    __: u8,
     #[bits(3)]
     priority_bits: u8,
     #[bits(1)]
@@ -61,6 +61,7 @@ impl Conversion<u32> for IdJ1939 {
     /// assert_eq!(0b000_000_0_0_00000000_00000000_00000000, id_a.into_bits());
     /// assert_eq!(0b111_111_1_1_11111111_11111111_11111111, id_b.into_bits());
     /// ```
+    #[inline]
     fn from_bits(bits: u32) -> Self {
         let bitfield = J1939(bits);
 
@@ -78,6 +79,7 @@ impl Conversion<u32> for IdJ1939 {
     /// assert_eq!(0b000_011_0_0_11110000_00000100_00000000, id_a.into_bits());
     /// assert_eq!(217056256, id_a.into_bits());
     /// ```
+    #[inline]
     fn from_hex(hex_str: &str) -> Self {
         let bits = u32::from_str_radix(hex_str, 16).unwrap_or_default();
         let bitfield = J1939(bits);
@@ -99,6 +101,7 @@ impl Conversion<u32> for IdJ1939 {
     /// assert_eq!(0b000_000_0_0_00000000_00000000_00000000, id_a.unwrap().into_bits());
     /// assert!(id_b.is_err());
     /// ```
+    #[inline]
     fn try_from_bits(bits: u32) -> Result<Self, Self::Error> {
         if bits > 0x1FFF_FFFF {
             return Err(anyhow::anyhow!(
@@ -126,6 +129,7 @@ impl Conversion<u32> for IdJ1939 {
     /// assert_eq!(0b000_0_0_11111111_00000000_11111111, id_a.into_bits());
     /// assert!(id_b.is_err())
     /// ```
+    #[inline]
     fn try_from_hex(hex_str: &str) -> Result<Self, Self::Error> {
         let bits = u32::from_str_radix(hex_str, 16).map_err(anyhow::Error::msg)?;
         if bits > 0x1FFF_FFFF {
@@ -148,6 +152,7 @@ impl Conversion<u32> for IdJ1939 {
     ///
     /// assert_eq!(0, id_a.into_bits());
     /// ```
+    #[inline]
     fn into_bits(self) -> u32 {
         self.0.into_bits()
     }
@@ -164,6 +169,7 @@ impl Conversion<u32> for IdJ1939 {
     ///
     /// assert_eq!("0000000F", id_a.into_hex());
     /// ```
+    #[inline]
     #[cfg(feature = "alloc")]
     fn into_hex(self) -> String {
         format(format_args!("{:08X}", self.0.into_bits()))
@@ -246,36 +252,42 @@ impl IdJ1939 {
     /// Returns the priority bits indicating the priority level.
     ///
     /// 0 = highest priority
+    #[inline]
     #[must_use]
     pub const fn priority(&self) -> u8 {
         self.0.priority_bits()
     }
 
     /// Returns the reserved flag - 0 or 1
+    #[inline]
     #[must_use]
     pub const fn reserved(&self) -> bool {
         self.0.reserved_bits()
     }
 
     /// Returns the data page flag - 0 or 1
+    #[inline]
     #[must_use]
     pub const fn data_page(&self) -> bool {
         self.0.data_page_bits()
     }
 
     /// Returns the PDU format bits specifying the Protocol Data Unit format.
+    #[inline]
     #[must_use]
     pub const fn pdu_format(&self) -> u8 {
         self.0.pdu_format_bits()
     }
 
     /// Returns the PDU specific bits providing additional details about the PDU.
+    #[inline]
     #[must_use]
     pub const fn pdu_specific(&self) -> u8 {
         self.0.pdu_specific_bits()
     }
 
     /// Returns the source address bits identifying the source of the data.
+    #[inline]
     #[must_use]
     pub fn source_address(&self) -> SourceAddr {
         SourceAddr::Some(self.0.source_address_bits())


### PR DESCRIPTION
Reduced code gen by `bitfield-struct`. Added inline for small but easy performance gains as well.